### PR TITLE
feat(profile): add account deletion flow

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,6 +29,7 @@ function Routes() {
         <Stack.Screen name="login" />
         <Stack.Screen name="forgot-password" />
         <Stack.Screen name="change-password" />
+        <Stack.Screen name="delete-account" />
         <Stack.Screen name="workout/[id]" />
       </Stack>
     </View>

--- a/app/delete-account.tsx
+++ b/app/delete-account.tsx
@@ -1,0 +1,157 @@
+import { UIButton } from '@/components/UI/Button';
+import { UIFormInput } from '@/components/UI/FormInput';
+import { useAuth } from '@/contexts/AuthProvider';
+import { useConfirmDialog } from '@/contexts/ConfirmDialogProvider';
+import { useSnackbar } from '@/contexts/SnackbarProvider';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Keyboard, ScrollView } from 'react-native';
+import { Icon, useTheme } from 'react-native-paper';
+import styled from 'styled-components/native';
+import { z } from 'zod';
+
+const schema = z.object({
+  password: z.string().min(1, 'Informe sua senha'),
+});
+
+const CONSEQUENCES = [
+  'Seus dados pessoais (nome, e-mail e foto) são apagados',
+  'Você sai de todas as equipes das quais participa',
+  'Você perde o acesso ao aplicativo imediatamente',
+];
+
+export default function DeleteAccountScreen() {
+  const router = useRouter();
+  const theme = useTheme();
+  const { snack } = useSnackbar();
+  const { deleteAccount } = useAuth();
+  const { openConfirmDialog } = useConfirmDialog();
+  const [loading, setLoading] = useState(false);
+
+  const { control, handleSubmit } = useForm({
+    resolver: zodResolver(schema),
+  });
+
+  const confirmDeletion = async (password: string) => {
+    setLoading(true);
+    try {
+      await deleteAccount(password);
+      snack('Sua conta foi excluída.');
+    } catch (error: any) {
+      if (error?.response?.status === 422) {
+        snack('Senha incorreta.');
+        return;
+      }
+
+      if (!error?.response) {
+        snack('Não foi possível conectar ao servidor. Verifique sua conexão.');
+        return;
+      }
+
+      snack('Não foi possível excluir a conta. Tente novamente.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onSubmit = handleSubmit(({ password }) => {
+    Keyboard.dismiss();
+
+    openConfirmDialog({
+      title: 'Excluir conta',
+      message:
+        'Esta ação é irreversível. Sua conta e seus dados pessoais serão excluídos e não poderão ser recuperados.',
+      confirmText: 'Excluir conta',
+      cancelText: 'Cancelar',
+      onConfirm: () => confirmDeletion(password),
+    });
+  });
+
+  return (
+    <ScrollView
+      showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      contentContainerStyle={{
+        gap: 20,
+        paddingHorizontal: 24,
+        paddingTop: 60,
+        paddingBottom: 60,
+      }}
+    >
+      <Header>
+        <BackButton onPress={() => router.back()}>
+          <Icon source="arrow-left" size={22} color={theme.colors.onSurface} />
+        </BackButton>
+        <ScreenTitle>Excluir conta</ScreenTitle>
+      </Header>
+
+      <Warning>
+        <WarningTitle>Esta ação é irreversível</WarningTitle>
+        {CONSEQUENCES.map((item) => (
+          <WarningItem key={item}>{`•  ${item}`}</WarningItem>
+        ))}
+      </Warning>
+
+      <Description>
+        Para continuar, confirme sua senha atual.
+      </Description>
+
+      <UIFormInput
+        control={control}
+        name="password"
+        label="Senha atual"
+        mode="outlined"
+        secureTextEntry
+      />
+
+      <UIButton
+        text="Excluir minha conta"
+        loading={loading}
+        onPress={onSubmit}
+        style={{ backgroundColor: theme.colors.error }}
+      />
+    </ScrollView>
+  );
+}
+
+const Header = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+`;
+
+const BackButton = styled.Pressable`
+  padding: 4px;
+`;
+
+const ScreenTitle = styled.Text`
+  font-size: 22px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.onSurface};
+`;
+
+const Warning = styled.View`
+  gap: 8px;
+  padding: 16px;
+  border-radius: 12px;
+  background-color: ${({ theme }) => theme.colors.errorContainer};
+`;
+
+const WarningTitle = styled.Text`
+  font-size: 15px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.error};
+`;
+
+const WarningItem = styled.Text`
+  font-size: 13px;
+  line-height: 20px;
+  color: ${({ theme }) => theme.colors.onSurface};
+`;
+
+const Description = styled.Text`
+  font-size: 14px;
+  color: ${({ theme }) => theme.colors.onSurfaceVariant};
+`;

--- a/components/Profile/DangerZone.tsx
+++ b/components/Profile/DangerZone.tsx
@@ -1,10 +1,12 @@
 import { UICard } from '@/components/UI/Card';
+import { useRouter } from 'expo-router';
 import { useTheme } from 'react-native-paper';
 import { ProfileRow } from './ProfileRow';
 import styled from 'styled-components/native';
 
 export function DangerZone() {
   const theme = useTheme();
+  const router = useRouter();
 
   return (
     <Section>
@@ -17,6 +19,7 @@ export function DangerZone() {
             title="Excluir conta"
             titleColor={theme.colors.error}
             subtitle="Remover permanentemente seus dados"
+            onPress={() => router.push('/delete-account')}
           />
         </Rows>
       </UICard>

--- a/contexts/AuthProvider.tsx
+++ b/contexts/AuthProvider.tsx
@@ -12,6 +12,7 @@ interface AuthContextType {
   login: (email: string, password: string) => Promise<void | Error>;
   logout: () => Promise<void>;
   forgotPassword: (email: string) => Promise<void>;
+  deleteAccount: (password: string) => Promise<void>;
   isLoading: boolean;
 }
 
@@ -78,21 +79,35 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
+  const clearLocalSession = async () => {
+    setUser(null);
+    await deleteItemAsync('pushToken');
+    await deleteItemAsync('token');
+    router.replace('/login');
+  };
+
   const logout = async () => {
     try {
       const pushToken = await getItemAsync('pushToken');
       if (pushToken) {
         await NotificationsService.removeToken(pushToken).catch(() => {});
-        await deleteItemAsync('pushToken');
       }
 
       await AuthService.logout();
-      setUser(null);
-      await deleteItemAsync('token');
-      router.replace('/login');
+      await clearLocalSession();
     } catch (error: any) {
       snack(error.message);
     }
+  };
+
+  /**
+   * The backend already revokes tokens and push tokens, so only the local
+   * state needs cleaning up. Errors bubble up so the screen can tell a wrong
+   * password from a failed request.
+   */
+  const deleteAccount = async (password: string) => {
+    await AuthService.deleteAccount(password);
+    await clearLocalSession();
   };
 
   const forgotPassword = async (email: string) => {
@@ -121,7 +136,15 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <AuthContext.Provider
-      value={{ user, setUser, login, logout, forgotPassword, isLoading }}
+      value={{
+        user,
+        setUser,
+        login,
+        logout,
+        forgotPassword,
+        deleteAccount,
+        isLoading,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -39,4 +39,8 @@ export default class AuthService {
   static forgotPassword(email: string): Promise<void> {
     return http.post('api/forgot-password', { email });
   }
+
+  static deleteAccount(password: string): Promise<void> {
+    return http.delete('/api/account', { data: { password } });
+  }
 }


### PR DESCRIPTION
### What?

Implementa o fluxo de exclusão de conta no app, consumindo o novo `DELETE /api/account` (guiwb/natare-api#29).

- Nova tela `app/delete-account.tsx`, acessível pela linha "Excluir conta" da Zona de perigo no Perfil (que até então não tinha ação).
- Aviso explícito de irreversibilidade, listando o que acontece (dados pessoais apagados, saída das equipes, perda imediata de acesso).
- Confirmação em duas etapas: a senha atual é exigida no formulário e um `ConfirmDialog` pede a confirmação final antes da chamada.
- `AuthProvider` ganha `deleteAccount(password)`; o `clearLocalSession()` foi extraído do `logout` e limpa `user`, `token` e `pushToken` do secure store, redirecionando para o login.
- Tratamento de erro visível: senha incorreta (422), falha de conexão e erro genérico, todos via snackbar.

Closes #3

### Why?

Requisito de privacidade (LGPD): o usuário precisa conseguir excluir a própria conta pelo app, sem depender de suporte. A dupla confirmação (senha + diálogo) protege contra exclusão acidental ou por aparelho desbloqueado.
